### PR TITLE
Fix return type error when running incremental on first time ETL.

### DIFF
--- a/src/DbLoader.php
+++ b/src/DbLoader.php
@@ -306,6 +306,6 @@ class DbLoader implements Loader
             ->whereNotNull($this->updateColumn)
             ->orderByDesc($this->updateColumn)
             ->limit(1)
-            ->value($this->updateColumn);
+            ->value($this->updateColumn) ?? '';
     }
 }


### PR DESCRIPTION
This PR addresses an issue where running `artisan etls:run <etl-name> --incremental` against an empty database table will silently fail due to a mismatched return type in `DbLoader::getIncrementalLastValue`.

`getIncrementalLastValue` use's Laravel's `Builder` object to build a query against the configured connection, ultimately returning the result of the `value` call. This works when the destination database table already has data, because it returns the value of the last row in the configured column. However, when the database table is empty, the `value` call returns `null`, which is not what `getIncrementalLastValue` expects to return. The type is not converted and the extraction fails.