### PR TITLE
Remove unused imports from commands; return successful status code

### DIFF
--- a/src/Commands/InfoCommand.php
+++ b/src/Commands/InfoCommand.php
@@ -2,7 +2,6 @@
 
 namespace ZiffMedia\LaravelEtls\Commands;
 
-use App\Etls\MerchantSeoDataEtl;
 use Illuminate\Support\Str;
 use ZiffMedia\LaravelEtls\AbstractEtl;
 use ZiffMedia\LaravelEtls\EtlExecutor;
@@ -58,5 +57,7 @@ class InfoCommand extends Command
             $this->output->writeln('Extractor query: ');
             $this->output->writeln($extractorQuery->toSql());
         }
+
+        return 0;
     }
 }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -11,7 +11,7 @@ class ListCommand extends Command
 {
     protected $signature = 'etls:list';
 
-    protected $description = 'Run ETLs';
+    protected $description = 'List ETLs';
 
     public function handle()
     {
@@ -20,5 +20,7 @@ class ListCommand extends Command
         foreach ($etls as $etlName => $etlClass) {
             $this->output->writeln(Str::kebab($etlName) . " found in class $etlClass");
         }
+
+        return 0;
     }
 }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -2,7 +2,6 @@
 
 namespace ZiffMedia\LaravelEtls\Commands;
 
-use App\Etls\MerchantSeoDataEtl;
 use Illuminate\Support\Str;
 use ZiffMedia\LaravelEtls\EtlExecutor;
 use Illuminate\Console\Command;

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -51,5 +51,7 @@ class RunCommand extends Command
         if ($this->output->isVerbose()) {
             $this->output->writeln("\nComplete");
         }
+
+        return 0;
     }
 }

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -2,7 +2,6 @@
 
 namespace ZiffMedia\LaravelEtls\Commands;
 
-use App\Etls\MerchantSeoDataEtl;
 use Illuminate\Support\Str;
 use ZiffMedia\LaravelEtls\EtlExecutor;
 use Illuminate\Console\Command;


### PR DESCRIPTION
It looks like there was a production class that was erroneously included in the imports here. I also went ahead and added returning the success status code.